### PR TITLE
fix: gyp on macos

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,8 @@
             ],
             "include_dirs": [
                 "<!@(node -p \"require('node-addon-api').include\")"
+                # gyp scan header files in macos
+                "<!@(pkg-config --variable=includedir rime)",
             ],
             "defines": [
                 "NAPI_DISABLE_CPP_EXCEPTIONS",


### PR DESCRIPTION
This PR fixes missing `json.h` on macOS. This is intended to be used with `librime` package from Homebrew tap [tonyfettes/rime](https://github.com/tonyfettes/homebrew-rime).

@Freed-Wu I didn't put macOS related config lines inside a condition block b/c they look pretty "platform independent" to me. Can you check if they work on your machines (android, linux, etc)? Thx in advance